### PR TITLE
Organize video into Lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,34 +12,33 @@ Kindly create your account [here](https://courses.calhoun.io/signup?). Jon is a 
 
 To install this package run
 
-```bash
-    $ go get -u github.com/timolinn/joncalhoun-dl
+```sh
+$ go get -u github.com/timolinn/joncalhoun-dl
 ```
 
 ### To build from source run
 
-```bash
-    $ git clone git@github.com:timolinn/joncalhoun-dl.git
-    $ cd joncalhoun-dl
-    $ go build .
+```sh
+$ git clone git@github.com:timolinn/joncalhoun-dl.git
+$ cd joncalhoun-dl
+$ go build .
 ```
 
 ## How to use
 
 If you installed via `go get`, you can simply run
 
-```bash
-    $ joncalhoun-dl -email=jon@doe.com -password=12345 -course=gophercises -output=your-chosen-directory
-     [joncalhoun-dl]: fetching video urls for gophercises
-     [joncalhoun-dl]: fetching data from https://courses.calhoun.io/courses/cor_gophercises...
+```sh
+$ joncalhoun-dl -email=jon@doe.com -password=12345 -course=gophercises -output=your-chosen-directory
+[joncalhoun-dl]: fetching video urls for gophercises
+[joncalhoun-dl]: fetching data from https://courses.calhoun.io/courses/cor_gophercises...
 ```
 
 If you built from source, the compiled binary should be in the current folder.
 
-```bash
-    $ ./joncalhoun-dl -email=jon@doe.com -password=12345 -course=gophercises -output=your-chosen-directory
-     [joncalhoun-dl]: fetching video urls for gophercises
-     [joncalhoun-dl]: fetching data from https://courses.calhoun.io/courses/cor_gophercises...
+```sh
+$ ./joncalhoun-dl -email=jon@doe.com -password=12345 -course=gophercises -output=your-chosen-directory[joncalhoun-dl]: fetching video urls for gophercises
+[joncalhoun-dl]: fetching data from https://courses.calhoun.io/courses/cor_gophercises...
 ```
 
 Also note, video downloads **resumes** from where it stopped, so should you experience network interruption nothing to worry about just make sure the output directory remains the same.
@@ -77,8 +76,8 @@ If you find a bug please create an [issue](https://github.com/timolinn/joncalhou
 
 To run existing tests
 
-```bash
-    $ go test
+```sh
+$ go test
 ```
 
 ## TODO
@@ -92,6 +91,7 @@ To run existing tests
 + [ ] prevent signin when using cache
 + [ ] choose video quality
 + [ ] reduce cache size by storing fewer data
++ [ ] delete cache folder after download finishes
 
 ### Authors
 

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 
 	for _, file := range files {
 
-		slc := strings.Split(match, "-")
+		slc := strings.Split(file, "-")
 		for i := range slc {
 			slc[i] = strings.TrimSpace(slc[i])
 		}
@@ -147,15 +147,14 @@ func main() {
 		video := strings.Join(slc[2:], " ")
 
 		// Create lesson directory if it does not exist yet
-		if !dirExists(odir + "/" + lesson) {
-			err := os.Mkdir(odir+"/"+lesson, 0755)
+		if !dirExists(*outputdir + "/" + lesson) {
+			err := os.Mkdir(*outputdir+"/"+lesson, 0755)
 			checkError(err)
 		}
 
-		fmt.Printf("Moving %s to %s/%s\n", match, lesson, video)
 		fmt.Printf("[joncalhoun-dl]: Moving %s to %s/%s\n", file, lesson, video)
 
-		os.Rename(match, lesson+"/"+video)
+		os.Rename(file, lesson+"/"+video)
 	}
 
 	fmt.Println("Done! 🚀")

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"path/filepath"
 
 	"github.com/PuerkitoBio/goquery"
 	"golang.org/x/net/publicsuffix"

--- a/main.go
+++ b/main.go
@@ -131,6 +131,33 @@ func main() {
 			fmt.Printf("[joncalhoun-dl]: Page for lesson 0%d does not have an embedded video \n", i+1)
 		}
 	}
+
+	os.Chdir(*outputdir)
+
+	files, _ := filepath.Glob("*.mp4")
+
+	for _, file := range files {
+
+		slc := strings.Split(match, "-")
+		for i := range slc {
+			slc[i] = strings.TrimSpace(slc[i])
+		}
+
+		lesson := strings.Join(slc[:2], " ")
+		video := strings.Join(slc[2:], " ")
+
+		// Create lesson directory if it does not exist yet
+		if !dirExists(odir + "/" + lesson) {
+			err := os.Mkdir(odir+"/"+lesson, 0755)
+			checkError(err)
+		}
+
+		fmt.Printf("Moving %s to %s/%s\n", match, lesson, video)
+		fmt.Printf("[joncalhoun-dl]: Moving %s to %s/%s\n", file, lesson, video)
+
+		os.Rename(match, lesson+"/"+video)
+	}
+
 	fmt.Println("Done! 🚀")
 }
 


### PR DESCRIPTION
Downloaded videos are moved into corresponding lesson folders.

### Example

The output  file structure of the current script looks similar to this:

```sh
.
├── Ex1 - Quiz Game - Intro.mp4
├── Ex1 - Quiz Game - Solution (part 1).mp4
├── Ex1 - Quiz Game - Solution (part 2).mp4
├── Ex2 - URL Shortener - Intro.mp4
├── Ex2 - URL Shortener - Solution.mp4
├── Ex3 - Choose Your Own Adventure - 01 - Intro.mp4
├── Ex3 - Choose Your Own Adventure - 02 - Parsing the JSON.mp4
├── Ex3 - Choose Your Own Adventure - 03 - Refactoring our JSON Parsing.mp4
├── Ex3 - Choose Your Own Adventure - 04 - Building the http Handler.mp4
├── Ex3 - Choose Your Own Adventure - 05 - Parsing Paths.mp4
├── Ex3 - Choose Your Own Adventure - 06 - Styling the HTML.mp4
```

This **pull request** contains commits that will organize downloaded video files into lesson folders, similar to this. 
```sh
.
├── Ex1 Quiz Game
│   ├── Intro.mp4
│   ├── Solution (part 1).mp4
│   └── Solution (part 2).mp4
├── Ex2 URL Shortener
│   ├── Intro.mp4
│   └── Solution.mp4
└── Ex3 Choose Your Own Adventure
    ├── 01 Intro.mp4
    ├── 02 Parsing the JSON.mp4
    ├── 03 Refactoring our JSON Parsing.mp4
    ├── 04 Building the http Handler.mp4
    ├── 05 Parsing Paths.mp4
    ├── 06 Styling the HTML.mp4
```